### PR TITLE
基于海明距离的相似图像识别

### DIFF
--- a/aiotieba/reviewer.py
+++ b/aiotieba/reviewer.py
@@ -419,19 +419,20 @@ class BaseReviewer(object):
 
         return img_hash
 
-    async def get_imghash(self, image: "np.ndarray") -> int:
+    async def get_imghash(self, image: "np.ndarray", hamming_distance: int=0) -> int:
         """
         获取图像的封锁级别
 
         Args:
             image (np.ndarray): 图像
+            hamming_distance: 最大海明距离 默认为0(图像phash完全一致)
 
         Returns:
             int: 封锁级别
         """
 
         if img_hash := self.compute_imghash(image):
-            return await self.db.get_imghash(img_hash)
+            return await self.db.get_imghash(img_hash, hamming_distance)
         return 0
 
     async def get_imghash_full(self, image: "np.ndarray") -> Tuple[int, str]:


### PR DESCRIPTION
原代码检测违规图像是基于图像phash的完全匹配，这导致同一幅违规图像可能因为某些细微的差异（例如右下角水印，原图与缩略图，二次压缩）而计算得到不同的phash，从而无法被检测出。例如，这是我曾遇到的两幅图像的phash值：
0600300d00040000
0600380c08040000
这两幅图片是同一张图，贴吧的raw_hash都一样，但计算得到的phash有3bit的差异，导致没有识别出违规图片。针对这种情况，可以检测图像phash的海明距离，而不是匹配完全相同的phash。通常，当两幅图像的64位phash的海明距离小于等于5位时，即可认为这两幅图像非常相似，大概率是同一张图。
我在函数`get_imghash`中添加了参数`hamming_distance`，当值不为0时，将筛选所有海明距离小于等于此值的图片；当值为0时，将匹配完全相同的phash（即原逻辑）。